### PR TITLE
feat: add chat sidebar

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { AIDevtools } from "@ai-sdk-tools/devtools";
-import { Suspense } from "react";
-import { ChatContent } from "./_components/chat-content";
+import { useChatSidebar } from "@/components/providers/chat-sidebar-provider";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function Page() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <ChatContent />
-      {process.env.NODE_ENV === "development" && <AIDevtools />}
-    </Suspense>
-  );
+  const { open } = useChatSidebar();
+  const router = useRouter();
+
+  useEffect(() => {
+    open();
+    router.replace("/");
+  }, [open, router]);
+
+  return null;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,9 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type React from "react";
 import { Suspense } from "react";
 import { ThemeProvider } from "@/components/providers/theme-provider";
+import { ChatSidebarProvider } from "@/components/providers/chat-sidebar-provider";
+import { ChatSidebar } from "@/components/chat-sidebar";
+import { LayoutWrapper } from "@/components/layout-wrapper";
 import { sans } from "@/lib/fonts";
 
 import "./globals.css";
@@ -34,18 +37,16 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased">
         <ThemeProvider attribute="class" defaultTheme="light">
-          <NuqsAdapter>
-            <Suspense fallback={null}>
-              <Header
-                leftItems={[{ key: "chat", label: "Chat", href: "/chat" }]}
-              />
-            </Suspense>
-            <main className="container mx-auto px-4 sm:px-6 lg:px-8 pt-[60px] print:pt-0">
-              {children}
-            </main>
-          </NuqsAdapter>
-          <GoogleAnalytics gaId="G-G7VF0PLE22" />
-          <ClarityProvider />
+          <ChatSidebarProvider>
+            <LayoutWrapper>
+              <NuqsAdapter>
+                {children}
+                <ChatSidebar />
+              </NuqsAdapter>
+              <GoogleAnalytics gaId="G-G7VF0PLE22" />
+              <ClarityProvider />
+            </LayoutWrapper>
+          </ChatSidebarProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/chat-sidebar.tsx
+++ b/components/chat-sidebar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useChatSidebar } from "@/components/providers/chat-sidebar-provider";
+import { ChatContent } from "@/app/chat/_components/chat-content";
+import { AIDevtools } from "@ai-sdk-tools/devtools";
+import { useHotkeys } from "react-hotkeys-hook";
+import { AnimatePresence, motion } from "motion/react";
+
+export function ChatSidebar() {
+  const { isOpen, close } = useChatSidebar();
+
+  // Close on Escape key - only active when sidebar is open
+  useHotkeys(
+    "escape",
+    () => {
+      close();
+    },
+    {
+      enabled: isOpen,
+      enableOnFormTags: true,
+    },
+  );
+
+  return (
+    <>
+      <AnimatePresence mode="wait">
+        {isOpen && (
+          <motion.aside
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ duration: 0.3, ease: "easeInOut" }}
+            className="fixed top-0 right-0 bottom-0 w-full md:w-[400px] lg:w-[480px] bg-background border-l z-50 overflow-y-auto"
+          >
+            <ChatContent />
+          </motion.aside>
+        )}
+      </AnimatePresence>
+
+      {process.env.NODE_ENV === "development" && <AIDevtools />}
+    </>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,20 +1,33 @@
+"use client";
+
 import Link from "next/link";
-// import { HeaderMenu } from "@/components/header-menu";
 import { TimezoneClock } from "@/components/timezone-clock";
+import { useChatSidebar } from "@/components/providers/chat-sidebar-provider";
+import { motion } from "motion/react";
+import { useEffect, useState } from "react";
 
-export type THeaderItem = {
-  key: string;
-  label: string;
-  href: string;
-};
+export function Header() {
+  const { toggle, isOpen } = useChatSidebar();
+  const [isDesktop, setIsDesktop] = useState(false);
 
-export type THeaderConfig = {
-  leftItems?: THeaderItem[];
-};
+  useEffect(() => {
+    const checkDesktop = () => {
+      setIsDesktop(window.innerWidth >= 768);
+    };
 
-export function Header({ leftItems = [] }: THeaderConfig) {
+    checkDesktop();
+    window.addEventListener("resize", checkDesktop);
+    return () => window.removeEventListener("resize", checkDesktop);
+  }, []);
+
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 print:hidden bg-background border-b">
+    <motion.header
+      animate={{
+        marginRight: isOpen && isDesktop ? "480px" : "0",
+      }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+      className="fixed top-0 left-0 right-0 z-50 print:hidden bg-background border-b"
+    >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-1.5">
         <div className="flex justify-between items-center">
           <div className="flex gap-x-4 items-center">
@@ -24,22 +37,18 @@ export function Header({ leftItems = [] }: THeaderConfig) {
             >
               Milind's Resume
             </Link>
-            {leftItems.map((item) => (
-              <Link
-                key={item.key}
-                href={item.href}
-                className="font-medium hover:underline text-sm md:text-md"
-              >
-                {item.label}
-              </Link>
-            ))}
+            <button
+              onClick={toggle}
+              className="font-medium hover:underline text-sm md:text-md"
+            >
+              Chat
+            </button>
           </div>
           <div className="flex gap-x-3 items-center">
             <TimezoneClock />
-            {/* <HeaderMenu /> */}
           </div>
         </div>
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/components/layout-content.tsx
+++ b/components/layout-content.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { Loading } from "@/components/loading";
-import { ResumeView } from "@/components/resume";
-import { resume } from "@/lib/resume";
-import { Header } from "@/components/header";
-import { Suspense } from "react";
-import { motion } from "motion/react";
 import { useChatSidebar } from "@/components/providers/chat-sidebar-provider";
+import type React from "react";
 import { useEffect, useState } from "react";
+import { motion } from "motion/react";
 
-export default function Page() {
+export function LayoutContent({ children }: { children: React.ReactNode }) {
   const { isOpen } = useChatSidebar();
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -30,13 +26,8 @@ export default function Page() {
       }}
       transition={{ duration: 0.3, ease: "easeInOut" }}
     >
-      <Suspense fallback={null}>
-        <Header />
-      </Suspense>
       <main className="container mx-auto px-4 sm:px-6 lg:px-8 pt-[60px] print:pt-0">
-        <Suspense fallback={<Loading />}>
-          <ResumeView data={resume} />
-        </Suspense>
+        {children}
       </main>
     </motion.div>
   );

--- a/components/layout-wrapper.tsx
+++ b/components/layout-wrapper.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import type React from "react";
+
+export function LayoutWrapper({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/components/providers/chat-sidebar-provider.tsx
+++ b/components/providers/chat-sidebar-provider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+
+type ChatSidebarContextType = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+};
+
+const ChatSidebarContext = createContext<ChatSidebarContextType | null>(null);
+
+export function useChatSidebar() {
+  const context = useContext(ChatSidebarContext);
+  if (!context) {
+    throw new Error("useChatSidebar must be used within ChatSidebarProvider");
+  }
+  return context;
+}
+
+export function ChatSidebarProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Memoize callbacks to prevent unnecessary re-renders
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  // Keyboard shortcut: Cmd/Ctrl + K to toggle chat
+  useHotkeys("mod+k", (e) => {
+    e.preventDefault();
+    toggle();
+  });
+
+  // Memoize context value to prevent unnecessary re-renders
+  const value = useMemo(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle]
+  );
+
+  return (
+    <ChatSidebarContext.Provider value={value}>
+      {children}
+    </ChatSidebarContext.Provider>
+  );
+}


### PR DESCRIPTION

<img width="2056" height="1254" alt="Screenshot 2026-02-06 at 10 00 00 PM" src="https://github.com/user-attachments/assets/fde5b784-4659-4869-b27b-8f95adfd2aa2" />


- Add chat sidebar component that slides in from the right on desktop (480px wide, full width on mobile)
- Implement chat sidebar context provider with open/close/toggle state management
- Add keyboard shortcuts: Cmd/Ctrl+K to toggle sidebar, / to focus chat input, Escape to close
- Refactor chat page to redirect to home and open sidebar
- Update main page layout to dynamically adjust margins when sidebar is open on desktop
- Optimize chat component with React.memo, useMemo, and useCallback for better performance
- Improve chat UI with fixed input at bottom, gradient overlay, and proper scroll handling
- Add animated transitions for sidebar and layout adjustments using Framer Motion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sidebar slides in from the right; toggle with Ctrl+K (Cmd+K on Mac)
  * Chat button added to header for quick access
  * Keyboard shortcuts: "/" to focus chat input, Escape to close sidebar
  * Layout now responds to chat sidebar visibility on desktop

<!-- end of auto-generated comment: release notes by coderabbit.ai -->