### PR TITLE
feat: add mobile web haptics support

### DIFF
--- a/components/chat-content.tsx
+++ b/components/chat-content.tsx
@@ -10,6 +10,7 @@ import {
 import { useSidebarActions } from "@/components/providers/chat-sidebar-store";
 import { TTSClientButton } from "@/components/tts-client-button";
 import { Button } from "@/components/ui/button";
+import { useAppHaptics } from "@/hooks/use-app-haptics";
 import { clearMessages, loadMessages, saveMessages } from "@/lib/chat-storage";
 import { cn } from "@/lib/utils";
 import type { ChatItem, ExtendedUIMessage } from "@/types/chat";
@@ -319,13 +320,16 @@ const Message = memo(function Message({
 });
 
 function Messages() {
-	const { messages, status, hasMessages } = useChatContext();
+	const { messages, status, hasMessages, isLoaded } = useChatContext();
+	const { trigger } = useAppHaptics();
 	const messageCount = useMessageCount();
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const prevMessageCountRef = useRef(0);
 	const shouldAutoScrollRef = useRef(true);
 	const scrollTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+	const lastAssistantMessageIdRef = useRef<string | null>(null);
+	const hasTrackedInitialAssistantRef = useRef(false);
 
 	// Compute chat items with date separators
 	const chatItems = useMemo((): ChatItem[] => {
@@ -424,6 +428,29 @@ function Messages() {
 		}
 	}, [hasMessages, messageCount, scrollToBottom]);
 
+	useEffect(() => {
+		const lastAssistantMessage = [...messages]
+			.reverse()
+			.find((message) => message.role === "assistant");
+
+		if (!isLoaded) return;
+
+		if (!hasTrackedInitialAssistantRef.current) {
+			lastAssistantMessageIdRef.current = lastAssistantMessage?.id ?? null;
+			hasTrackedInitialAssistantRef.current = true;
+			return;
+		}
+
+		if (
+			status === "ready" &&
+			lastAssistantMessage?.id &&
+			lastAssistantMessage.id !== lastAssistantMessageIdRef.current
+		) {
+			lastAssistantMessageIdRef.current = lastAssistantMessage.id;
+			void trigger("soft", { intensity: 0.5 });
+		}
+	}, [isLoaded, messages, status, trigger]);
+
 	if (!hasMessages) return null;
 
 	return (
@@ -457,6 +484,7 @@ function Messages() {
 
 function Welcome() {
 	const { hasMessages, sendMessage } = useChatContext();
+	const { trigger } = useAppHaptics();
 
 	if (hasMessages) return null;
 
@@ -469,6 +497,7 @@ function Welcome() {
 	];
 
 	const handlePromptClick = (prompt: string) => {
+		void trigger("rigid", { intensity: 0.9 });
 		sendMessage({ text: prompt });
 	};
 
@@ -524,6 +553,7 @@ function ClearButton() {
 function ChatSidebarHeader() {
 	const { hasMessages, clearChat } = useChatContext();
 	const { close } = useSidebarActions();
+	const { trigger } = useAppHaptics();
 
 	return (
 		<header className="shrink-0 bg-background border-b">
@@ -536,7 +566,10 @@ function ChatSidebarHeader() {
 						{hasMessages && (
 							<button
 								type="button"
-								onClick={clearChat}
+								onClick={() => {
+									void trigger("light", { intensity: 0.35 });
+									void clearChat();
+								}}
 								aria-label="Start new chat"
 								title="Start new chat"
 								className="font-medium hover:opacity-70 transition-opacity cursor-pointer p-1 -m-1"
@@ -546,7 +579,10 @@ function ChatSidebarHeader() {
 						)}
 						<button
 							type="button"
-							onClick={close}
+							onClick={() => {
+								void trigger("light", { intensity: 0.45 });
+								close();
+							}}
 							aria-label="Close chat sidebar"
 							title="Close chat sidebar"
 							className="flex shrink-0 p-1 -m-1 hover:opacity-70 transition-opacity cursor-pointer"
@@ -562,13 +598,15 @@ function ChatSidebarHeader() {
 
 function Input() {
 	const { sendMessage, status, stop, input, setInput } = useChatContext();
+	const { trigger } = useAppHaptics();
 
 	const handleSubmit = useCallback(() => {
 		if (input.trim() && status === "ready") {
+			void trigger("rigid", { intensity: 0.9 });
 			sendMessage({ text: input });
 			setInput("");
 		}
-	}, [input, status, sendMessage, setInput]);
+	}, [input, sendMessage, setInput, status, trigger]);
 
 	return (
 		<div>
@@ -602,6 +640,7 @@ function Input() {
 								onClick={(e) => {
 									if (status === "submitted") {
 										e.preventDefault();
+										void trigger("soft", { intensity: 0.7 });
 										stop();
 									}
 								}}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,6 +6,7 @@ import {
 	useSidebarOpen,
 	useSidebarResizing,
 } from "@/components/providers/chat-sidebar-store";
+import { useAppHaptics } from "@/hooks/use-app-haptics";
 import { useIsDesktop } from "@/hooks/use-media-query";
 import Link from "next/link";
 import { useMemo } from "react";
@@ -14,6 +15,7 @@ export function Header() {
 	const isOpen = useSidebarOpen();
 	const isResizing = useSidebarResizing();
 	const { toggle } = useSidebarActions();
+	const { trigger } = useAppHaptics();
 	const isDesktop = useIsDesktop();
 
 	const headerStyle = useMemo(
@@ -65,7 +67,10 @@ export function Header() {
 							{!isOpen && (
 								<button
 									type="button"
-									onClick={toggle}
+									onClick={() => {
+										void trigger("medium", { intensity: 0.75 });
+										toggle();
+									}}
 									aria-label="Open chat sidebar"
 									aria-expanded={false}
 									className="font-medium hover:underline text-sm md:text-md cursor-pointer"

--- a/components/install-strip.tsx
+++ b/components/install-strip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useAppHaptics } from "@/hooks/use-app-haptics";
 import { usePwaInstall } from "@/hooks/use-pwa-install";
 import { cn } from "@/lib/utils";
 import { Download, X } from "lucide-react";
@@ -11,6 +12,7 @@ const INSTALL_STRIP_HEIGHT_VAR = "--install-strip-height";
 export function InstallStrip() {
 	const { canInstall, dismiss, hasPrompt, isIos, promptToInstall } =
 		usePwaInstall();
+	const { trigger } = useAppHaptics();
 	const [showIosHelp, setShowIosHelp] = useState(false);
 	const ref = useRef<HTMLDivElement | null>(null);
 
@@ -42,11 +44,15 @@ export function InstallStrip() {
 
 	const handlePrimaryAction = async () => {
 		if (hasPrompt) {
-			await promptToInstall();
+			const installed = await promptToInstall();
+			void trigger(installed ? "success" : "selection", {
+				intensity: installed ? 0.8 : 0.55,
+			});
 			return;
 		}
 
 		if (isIos) {
+			void trigger("selection", { intensity: 0.55 });
 			setShowIosHelp((current) => !current);
 		}
 	};
@@ -82,7 +88,10 @@ export function InstallStrip() {
 						variant="ghost"
 						size="icon-sm"
 						aria-label="Dismiss install prompt"
-						onClick={dismiss}
+						onClick={() => {
+							void trigger("light", { intensity: 0.35 });
+							dismiss();
+						}}
 					>
 						<X className="size-4" />
 					</Button>

--- a/components/resume.tsx
+++ b/components/resume.tsx
@@ -8,6 +8,7 @@ import {
 	registerJsonToggleHandler,
 	unregisterJsonToggleHandler,
 } from "@/components/providers/keyboard-shortcuts";
+import { useAppHaptics } from "@/hooks/use-app-haptics";
 import {
 	calculateDuration,
 	formatDate,
@@ -121,11 +122,19 @@ const COPIED_DISPLAY_DURATION_MS = 1800;
 
 function EmailWithCopy({ email }: { email: string }) {
 	const [displayText, setDisplayText] = useState(email);
+	const { trigger } = useAppHaptics();
 
-	const handleClick = useCallback(() => {
-		void navigator.clipboard.writeText(email);
-		setDisplayText("Copied to clipboard!");
-	}, [email]);
+	const handleClick = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(email);
+			void trigger("success", { intensity: 0.8 });
+			setDisplayText("Copied to clipboard!");
+		} catch (error) {
+			if (process.env.NODE_ENV !== "production") {
+				console.warn("Failed to copy email:", error);
+			}
+		}
+	}, [email, trigger]);
 
 	useEffect(() => {
 		if (displayText !== "Copied to clipboard!") return;
@@ -518,6 +527,7 @@ function TalkPresentationItem({ item }: { item: Talks }) {
 
 function SkillsProficiency({ skills }: { skills: Skill[] }) {
 	const { sendPromptToChat } = useSidebarActions();
+	const { trigger } = useAppHaptics();
 
 	if (!skills?.length) return null;
 
@@ -529,6 +539,7 @@ function SkillsProficiency({ skills }: { skills: Skill[] }) {
 					key={skill}
 					onClick={() => {
 						const prompt = `Tell me about ${skill} - what is it, and how has Milind used this skill in his work? How proficient is he with ${skill}?`;
+						void trigger("medium", { intensity: 0.75 });
 						sendPromptToChat(prompt);
 					}}
 					className="hover:underline cursor-pointer"

--- a/components/tts-client-button.tsx
+++ b/components/tts-client-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useAppHaptics } from "@/hooks/use-app-haptics";
 import { markdownToSpeech } from "@/lib/markdown-to-speech";
 import { useSpeechSynthesis } from "@/hooks/use-speech-synthesis";
 import { Volume2, VolumeX } from "lucide-react";
@@ -16,9 +17,11 @@ interface TTSClientButtonProps {
  */
 export function TTSClientButton({ text }: TTSClientButtonProps) {
   const { speak, cancel, isSpeaking, isSupported } = useSpeechSynthesis();
+  const { trigger } = useAppHaptics();
 
   const handleToggle = useCallback(() => {
     if (isSpeaking) {
+      void trigger("soft", { intensity: 0.7 });
       cancel();
     } else {
       // Clean markdown formatting before speaking
@@ -29,9 +32,10 @@ export function TTSClientButton({ text }: TTSClientButtonProps) {
         return;
       }
 
+      void trigger("selection", { intensity: 0.55 });
       speak(cleanText);
     }
-  }, [isSpeaking, text, speak, cancel]);
+  }, [cancel, isSpeaking, speak, text, trigger]);
 
   // Hide button if browser doesn't support Web Speech API
   if (!isSupported) {

--- a/hooks/use-app-haptics.ts
+++ b/hooks/use-app-haptics.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { HapticInput, TriggerOptions } from "web-haptics";
+import { useWebHaptics } from "web-haptics/react";
+
+function isStandaloneMode() {
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    Boolean(
+      (window.navigator as Navigator & { standalone?: boolean }).standalone,
+    )
+  );
+}
+
+export function useAppHaptics() {
+  const { trigger, isSupported } = useWebHaptics();
+  const [isEligibleDevice, setIsEligibleDevice] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const coarsePointerQuery = window.matchMedia("(pointer: coarse)");
+    const reducedMotionQuery = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    );
+
+    const syncEligibility = () => {
+      setIsEligibleDevice(
+        (coarsePointerQuery.matches || isStandaloneMode()) &&
+          !reducedMotionQuery.matches,
+      );
+    };
+
+    syncEligibility();
+    coarsePointerQuery.addEventListener("change", syncEligibility);
+    reducedMotionQuery.addEventListener("change", syncEligibility);
+
+    return () => {
+      coarsePointerQuery.removeEventListener("change", syncEligibility);
+      reducedMotionQuery.removeEventListener("change", syncEligibility);
+    };
+  }, []);
+
+  const gatedTrigger = useCallback(
+    (input?: HapticInput, options?: TriggerOptions) => {
+      if (!isSupported || !isEligibleDevice) return;
+      return trigger(input, options);
+    },
+    [isEligibleDevice, isSupported, trigger],
+  );
+
+  return {
+    isSupported: isSupported && isEligibleDevice,
+    trigger: gatedTrigger,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "tokenlens": "^1.3.1",
     "torph": "^0.0.5",
     "use-stick-to-bottom": "^1.1.1",
+    "web-haptics": "^0.0.6",
     "zod": "^4.3.6",
     "zustand": "^5.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       use-stick-to-bottom:
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.0)
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -3576,6 +3579,23 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -7409,6 +7429,11 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.0.8: {}
+
+  web-haptics@0.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- add web-haptics for mobile web and installed PWA usage
- replace the custom haptics event mapping with direct preset + intensity calls at each interaction point
- wire haptics into chat, install, copy, and TTS interactions while keeping device/reduced-motion gating centralized

## Testing
- pnpm run typecheck
- pnpm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added haptic feedback (device vibrations) to user interactions throughout the app, including message sending, button clicks, text copying, and text-to-speech controls.
  * Haptic responses now provide tactile feedback for assistant responses and user actions when supported by your device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->